### PR TITLE
Added Auto-Publish of Tagged Versions on `main`

### DIFF
--- a/.github/workflows/release_on_tag.yaml
+++ b/.github/workflows/release_on_tag.yaml
@@ -26,12 +26,19 @@ jobs:
         run: python -m pip install poetry
       - name: Check PyProject Module Version
         run: |
-          python -m pip install toml
+          python -m pip install toml PyYAML
           MODULE_TAG=$(python -c "import toml; meta=toml.load('pyproject.toml');print(meta['tool']['poetry']['version'])" | xargs)
+          CITATION_TAG=$(python -c "import yaml; meta=yaml.safe_load(open('CITATION.cff'));print(meta['version'])" | xargs)
           if [ "$MODULE_TAG" != "${{ steps.tagName.outputs.tag }}" ]
           then 
-            echo "Tag mismatch between git and Python module, aborting.";
+            echo "Tag mismatch between git and Python module, aborting: $MODULE_TAG != ${{ steps.tagName.outputs.tag }}";
             echo "Update the module version either using 'poetry version' command or edit the 'pyproject.toml' file."
+            exit 1;
+          fi
+          if [ "$CITATION_TAG" != "${{ steps.tagName.outputs.tag }}" ]
+          then 
+            echo "Tag mismatch between git and CITATION file, aborting: $CITATION_TAG != ${{ steps.tagName.outputs.tag }}";
+            echo "Update the 'version' tag in the CITATION file."
             exit 1;
           fi
       - name: Build Module

--- a/.github/workflows/release_on_tag.yaml
+++ b/.github/workflows/release_on_tag.yaml
@@ -1,0 +1,47 @@
+# Publishes any tag which does not have a suffix
+# i.e. 0.1.0 would be published but not 0.1.0-rc1, 0.1.0-beta etc.
+# in addition, if the version number in the pyproject.toml has not been
+# updated as it should have been then this will terminate the CI
+
+name: Publish Release
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  publish_to_pypi:
+    runs-on: ubuntu-latest
+    name: Publish to PyPi
+    steps:
+      - uses: actions/checkout@v2
+      - name: Retrieve Tag
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "v(.*)"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install Poetry
+        run: python -m pip install poetry
+      - name: Check PyProject Module Version
+        run: |
+          MODULE_TAG=$(python -c "import toml; meta=toml.load('pyproject.toml');print(meta['tool']['poetry']['version'])" | xargs)
+          if [ "$MODULE_TAG" != "${{ steps.tagName.outputs.tag }}" ]
+          then 
+            echo "Tag mismatch between git and Python module, aborting.";
+            echo "Update the module version either using 'poetry version' command or edit the 'pyproject.toml' file."
+            exit 1;
+          fi
+      - name: Build Module
+        run: |
+          poetry install
+          poetry build
+          ls dist/
+      # - name: Publish Module to PyPi
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
+
+

--- a/.github/workflows/release_on_tag.yaml
+++ b/.github/workflows/release_on_tag.yaml
@@ -1,11 +1,13 @@
 # Publishes any tag which does not have a suffix
-# i.e. 0.1.0 would be published but not 0.1.0-rc1, 0.1.0-beta etc.
+# i.e. v0.1.0 would be published but not v0.1.0-rc1, v0.1.0-beta etc.
 # in addition, if the version number in the pyproject.toml has not been
 # updated as it should have been then this will terminate the CI
 
 name: Publish Release
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
@@ -46,10 +48,10 @@ jobs:
           poetry install
           poetry build
           ls dist/
-      # - name: Publish Module to PyPi
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish Module to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
 

--- a/.github/workflows/release_on_tag.yaml
+++ b/.github/workflows/release_on_tag.yaml
@@ -26,7 +26,7 @@ jobs:
         run: python -m pip install poetry
       - name: Check PyProject Module Version
         run: |
-          MODULE_TAG=$(python -c "import toml; meta=toml.load('pyproject.toml');print(meta['tool']['poetry']['version'])" | xargs)
+          MODULE_TAG=$(poetry run python -c "import toml; meta=toml.load('pyproject.toml');print(meta['tool']['poetry']['version'])" | xargs)
           if [ "$MODULE_TAG" != "${{ steps.tagName.outputs.tag }}" ]
           then 
             echo "Tag mismatch between git and Python module, aborting.";

--- a/.github/workflows/release_on_tag.yaml
+++ b/.github/workflows/release_on_tag.yaml
@@ -26,7 +26,8 @@ jobs:
         run: python -m pip install poetry
       - name: Check PyProject Module Version
         run: |
-          MODULE_TAG=$(poetry run python -c "import toml; meta=toml.load('pyproject.toml');print(meta['tool']['poetry']['version'])" | xargs)
+          python -m pip install toml
+          MODULE_TAG=$(python -c "import toml; meta=toml.load('pyproject.toml');print(meta['tool']['poetry']['version'])" | xargs)
           if [ "$MODULE_TAG" != "${{ steps.tagName.outputs.tag }}" ]
           then 
             echo "Tag mismatch between git and Python module, aborting.";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fair-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Synchronization interface for the SCRC FAIR Data Pipeline registry"
 authors = [
     "Nathan Cummings <nathan.cummings@ukaea.uk>",


### PR DESCRIPTION
Versions tagged with `vX.Y.Z` (no suffix) will be considered candidates for release, a check will then be performed to make sure that the git tag, `pyproject.toml` version number and `CITATION.cff` version number are the same.