### PR TITLE
Windows Fixes

### DIFF
--- a/fair/configuration.py
+++ b/fair/configuration.py
@@ -20,6 +20,7 @@ Functions
 __date__ = "2021-07-02"
 
 import os
+import platform
 import pathlib
 import uuid
 import copy
@@ -324,6 +325,8 @@ def get_local_port(local_uri: str = None) -> str:
         local_uri = get_local_uri()
     _port_res = re.findall(r'localhost:([0-9]+)', local_uri)
     if not _port_res:
+        _port_res = re.findall(r'127.0.0.1:([0-9]+)', local_uri)
+    if not _port_res:
         raise fdp_exc.InternalError(
             "Failed to determine port number from local registry URL"
         )
@@ -411,6 +414,8 @@ def global_config_query(registry: str = None) -> typing.Dict[str, typing.Any]:
         fdp_serv.install_registry()
 
     _default_url = 'http://localhost:8000/api/'
+    if platform.system() == "Windows":
+        _default_url = 'http://127.0.0.1:8000/api/'
     _local_uri = click.prompt("Local Registry URL", default=_default_url)
 
     _default_rem = 'https://data.scrc.uk/api/'

--- a/fair/registry/requests.py
+++ b/fair/registry/requests.py
@@ -26,6 +26,7 @@ import typing
 import copy
 import urllib.parse
 import re
+from requests.api import request
 import yaml
 import requests
 

--- a/fair/registry/server.py
+++ b/fair/registry/server.py
@@ -26,6 +26,7 @@ import glob
 import sys
 import enum
 import requests
+import platform
 
 import fair.common as fdp_com
 import fair.exceptions as fdp_exc
@@ -88,6 +89,12 @@ def launch_server(local_uri: str = None, registry_dir: str = None, verbose: bool
         registry_dir, "scripts", "start_fair_registry"
     )
 
+    if platform.system() == "Windows":
+        registry_dir = fdp_com.registry_home()
+        _server_start_script = os.path.join(
+            registry_dir, "scripts", "start_fair_registry_windows.bat"
+        )
+
     if not os.path.exists(_server_start_script):
         raise fdp_exc.RegistryError(
             f"Failed to find local registry executable '{_server_start_script}',"
@@ -103,7 +110,7 @@ def launch_server(local_uri: str = None, registry_dir: str = None, verbose: bool
         shell=False,
     )
 
-    if verbose:
+    if verbose and platform.system() != "Windows":
         for c in iter(lambda: _start.stdout.read(1), b""):
             sys.stdout.buffer.write(c)
 
@@ -143,6 +150,11 @@ def stop_server(
     _server_stop_script = os.path.join(
         fdp_com.registry_home(), "scripts", "stop_fair_registry"
     )
+
+    if platform.system() == "Windows":
+        _server_stop_script = os.path.join(
+            fdp_com.registry_home(), "scripts", "stop_fair_registry_windows.bat"
+            )
 
     if not os.path.exists(_server_stop_script):
         raise fdp_exc.RegistryError(

--- a/fair/run.py
+++ b/fair/run.py
@@ -59,6 +59,10 @@ SHELLS: typing.Dict[str, str] = {
         "exec": "{0}",
         "extension": "bat"
     },
+    "powershell": {
+        "exec": "powershell -command \". '{0}'\"",
+        "extension": "ps1"
+    },
     "python2": {
         "exec": "python2 {0}",
         "extension": "py"

--- a/fair/run.py
+++ b/fair/run.py
@@ -55,9 +55,9 @@ SHELLS: typing.Dict[str, str] = {
         "exec": "pwsh -command \". '{0}'\"",
         "extension": "ps1"
     },
-    "powershell": {
-        "powershell": "-command \". '{0}'\".",
-        "extension": "ps1"
+    "batch": {
+        "exec": "{0}",
+        "extension": "bat"
     },
     "python2": {
         "exec": "python2 {0}",
@@ -361,7 +361,9 @@ def run_command(
 
         if mode == CMD_MODE.RUN:
             _logger.debug("Executing command: %s", ' '.join(_cmd_list))
-
+            _shell = False
+            if platform.system() == "Windows":
+                _shell = True
             # Run the submission script
             _process = subprocess.Popen(
                 _cmd_list,
@@ -370,7 +372,7 @@ def run_command(
                 universal_newlines=True,
                 bufsize=1,
                 text=True,
-                shell=False,
+                shell=_shell,
                 env=_cmd_setup["env"],
                 cwd=_run_dir
             )
@@ -541,7 +543,7 @@ def setup_job_script(
         _shell = _conf_yaml["run_metadata"]["shell"]
     else:
         if platform.system() == "Windows":
-            _shell = "pwsh"
+            _shell = "batch"
         else:
             _shell = "sh"
 

--- a/fair/testing.py
+++ b/fair/testing.py
@@ -1,6 +1,7 @@
 import typing
 import tempfile
 import os
+import platform
 import git
 
 import fair.common as fdp_com
@@ -43,4 +44,7 @@ def create_configurations(registry_dir: str) -> typing.Dict:
             'remote': 'origin'
         },
     }
+    if platform.system() == "Windows":
+        _config_dict['registries']['local']['uri'] = 'http://127.0.0.1:8000/api/'
+        _config_dict['registries']['origin']['uri'] = 'http://127.0.0.1:8001/api/'
     return _config_dict

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -77,7 +77,7 @@ def test_run_setup_default_windows(mocker, setup_with_opts, no_registry_autoinst
     mocker.patch.object(platform, "system", lambda *args: "Windows")
     _cmd = 'Write-Host "Test Run"'
     _out, _cfg = setup_with_opts({"script": _cmd})
-    assert _out["shell"] == "pwsh"
+    assert _out["shell"] == "batch"
     assert open(_out['script']).read() == _cmd
     assert _out["env"]["FDP_LOCAL_REPO"] == _cfg["run_metadata"]['local_repo']
 


### PR DESCRIPTION
Pull request to make FAIR_CLI work with windows including:

- Using 127.0.0.1 instead of localhost to avoid windows DNS delay
- Using batch scripts as default for windows instead of powershell to overcome execution policy restrictions and dificulties in using the run command
- Disabling verbose output on fair start registry on windows to prevent the script hanging.
- Using shell = True on windows Popen to allow environmental variables to be used.