### PR TITLE
Remove commas from CMD_MODE enum

### DIFF
--- a/fair/common.py
+++ b/fair/common.py
@@ -50,9 +50,9 @@ FAIR_FOLDER = ".fair"
 JOBS_DIR = "jobs"
 
 class CMD_MODE(enum.Enum):
-    RUN = 1,
-    PULL = 2,
-    PUSH = 3,
+    RUN = 1
+    PULL = 2
+    PUSH = 3
     PASS = 4
 
 


### PR DESCRIPTION
Bug where commas have been placed in the `CMD_MODE` enum.