### PR TITLE
Ensure earlier termination if specified config.yaml not found

### DIFF
--- a/fair/cli.py
+++ b/fair/cli.py
@@ -92,9 +92,8 @@ def create(debug, output: str) -> None:
 @cli.command()
 @click.option(
     "--config",
-    help="Specify alternate location for generated config.yaml",
-    default=fdp_com.local_user_config(os.getcwd()),
-    shell_complete=complete_yamls,
+    help="Create a starter user config.yaml file during initialisation",
+    default=None,
 )
 @click.option(
     "--using",
@@ -119,7 +118,7 @@ def init(
     """Initialise repository in current location"""
     try:
         with fdp_session.FAIR(
-            os.getcwd(), config, debug=debug, testing=ci
+            os.getcwd(), None, debug=debug, testing=ci
         ) as fair_session:
             _use_dict = {}
             if using:
@@ -132,6 +131,8 @@ def init(
             fair_session.initialise(
                 using=_use_dict, registry=registry, export_as=export
             )
+            if config:
+                fair_session.make_starter_config(config)
     except fdp_exc.FAIRCLIException as e:
         if debug:
             raise e

--- a/fair/session.py
+++ b/fair/session.py
@@ -107,6 +107,13 @@ class FAIR:
         self._session_id = (
             uuid.uuid4() if server_mode == fdp_serv.SwitchMode.CLI else None
         )
+
+        if user_config and not os.path.exists(user_config):
+            raise fdp_exc.FileNotFoundError(
+                f"Cannot launch session from configuration file '{user_config}', "
+                "file not found."
+            )
+
         self._session_config = user_config or fdp_com.local_user_config(
             self._session_loc
         )

--- a/fair/session.py
+++ b/fair/session.py
@@ -95,6 +95,8 @@ class FAIR:
             stop/start server mode during session
         testing : bool
             run in testing mode
+        generate_config : bool
+            if the specified config.yaml does not exist generate it
         """
         if debug:
             logging.getLogger("FAIRDataPipeline").setLevel(logging.DEBUG)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,7 @@ def test_init_from_existing(
             )
             assert _result.exit_code == 0
             assert os.path.exists(_out_cli_config)
+            assert os.path.exists(_out_config)
             assert os.path.exists(os.path.join(os.getcwd(), fdp_com.FAIR_FOLDER))
 
             click_test = click.testing.CliRunner()


### PR DESCRIPTION
This stops the session generating a default config if one is already specified but does not exist.