### PR TITLE
Pre-initialisation registry install fix

### DIFF
--- a/fair/registry/server.py
+++ b/fair/registry/server.py
@@ -311,13 +311,10 @@ def install_registry(
     logger.debug("Updating registry path in global CLI configuration")
     if os.path.exists(fdp_com.global_fdpconfig()):
         _glob_conf = fdp_util.flatten_dict(fdp_conf.read_global_fdpconfig())
-    else:
-        _glob_conf = {}
+        _glob_conf["registries.local.directory"] = install_dir
 
-    _glob_conf["registries.local.directory"] = install_dir
-
-    with open(fdp_com.global_fdpconfig(), "w") as out_conf:
-        yaml.dump(fdp_util.expand_dict(_glob_conf), out_conf)
+        with open(fdp_com.global_fdpconfig(), "w") as out_conf:
+            yaml.dump(fdp_util.expand_dict(_glob_conf), out_conf)
 
     if force:
         logger.debug("Removing existing installation at '%s'", install_dir)

--- a/fair/session.py
+++ b/fair/session.py
@@ -196,6 +196,14 @@ class FAIR:
                 click.echo(f"Removing directory '{_root_dir}'")
             shutil.rmtree(_root_dir)
         if clear_all:
+            try:
+                if fdp_serv.check_server_running():
+                    fdp_serv.stop_server()
+            except fdp_exc.CLIConfigurationError:
+                click.echo(
+                    "Warning: Unable to check if server is running, "
+                    "you may need to manually terminate the Django process"
+                )
             if verbose and os.path.exists(fdp_com.USER_FAIR_DIR):
                 click.echo(f"Removing directory '{fdp_com.USER_FAIR_DIR}'")
             shutil.rmtree(fdp_com.USER_FAIR_DIR)


### PR DESCRIPTION
Fixes a bug where the global config is partially made when the registry is installed, this causes things to break later on if purging etc.