### PR TITLE
Fix `fair push` to use parameters

### DIFF
--- a/.github/workflows/fair-cli.yaml
+++ b/.github/workflows/fair-cli.yaml
@@ -28,6 +28,8 @@ jobs:
         run: python -m pip install poetry
       - name: Install Module
         run: python -m poetry install
+      - name: Install Python API for API Tests
+        run: python -m poetry run pip install git+https://github.com/FAIRDataPipeline/pyDataPipeline.git@dev
       - name: Run Tests
         run: python -m poetry run pytest --cov=fair --cov-report=xml --cov-report=term -s tests/
       - uses: codecov/codecov-action@v2

--- a/fair/parsing/globbing.py
+++ b/fair/parsing/globbing.py
@@ -28,6 +28,7 @@ import fair.exceptions as fdp_exc
 import fair.registry.requests as fdp_req
 import fair.registry.versioning as fdp_ver
 import fair.utilities as fdp_util
+import fair.register as fdp_reg
 
 
 def glob_read_write(
@@ -91,7 +92,7 @@ def glob_read_write(
         _key_glob, _globbable = _glob_vals[0]
 
         if not search_key:
-            search_key = fdp_req.SEARCH_KEYS[_key_glob]
+            search_key = fdp_reg.SEARCH_KEYS[_key_glob]
 
         _search_dict = {search_key: _globbable}
 

--- a/fair/register.py
+++ b/fair/register.py
@@ -34,6 +34,41 @@ import fair.registry.storage as fdp_store
 import fair.registry.versioning as fdp_ver
 
 
+SEARCH_KEYS = {
+    "data_product": "name",
+    "namespace": "name",
+    "file_type": "extension",
+    "storage_root": "root",
+    "storage_location": "hash",
+}
+
+
+def convert_key_value_to_id(uri: str, obj_type: str, value: str, check: bool = False) -> int:
+    """Converts a config key value to the relevant URL on the local registry
+
+    Parameters
+    ----------
+    uri: str
+        registry endpoint to use for obtaining URL 
+    obj_type : str
+        object type
+    value : str
+        search term to use
+
+    Returns
+    -------
+    int
+        ID on the local registry matching the entry
+    """
+    _params = {SEARCH_KEYS[obj_type]: value}
+    _result = fdp_req.get(uri, obj_type, params=_params)
+    if not _result:
+        raise fdp_exc.RegistryError(
+            f"Failed to obtain result for '{obj_type}' with parameters '{_params}'"
+        )
+    return fdp_req.get_obj_id_from_url(_result[0]["url"])
+
+
 # flake8: noqa: C901
 def fetch_registrations(
     local_uri: str,
@@ -79,6 +114,7 @@ def fetch_registrations(
 
         _data_product = None
         _external_object = None
+        _is_present = None
 
         _search_data = {}
 
@@ -112,8 +148,12 @@ def fetch_registrations(
                     "Expected either 'identifier', or 'unique_name' and "
                     f"'alternate_identifier_type' in external object '{_name}'"
                 )
-            _search_data["namespace"] = entry["use"]["namespace"]
-            _search_data["data_product"] = entry["use"]["data_product"]
+            try:
+                _data_product_id = convert_key_value_to_id(local_uri, "data_product", entry["use"]["data_product"])
+                _search_data["data_product"] = _data_product_id
+            except fdp_exc.RegistryError:
+                _is_present = "absent"
+
         else:
             _name = entry["use"]["data_product"]
             _obj_type = "data_product"
@@ -192,10 +232,10 @@ def fetch_registrations(
         os.makedirs(_local_dir, exist_ok=True)
 
         _local_file = os.path.join(_local_dir, f"{_user_version}.{entry['file_type']}")
-
         # Copy the temporary file into the data store
         # then remove temporary file to save space
         shutil.copy(_temp_data_file, _local_file)
+
         if "cache" not in entry:
             os.remove(_temp_data_file)
 

--- a/fair/session.py
+++ b/fair/session.py
@@ -338,8 +338,13 @@ class FAIR:
 
         self._logger.debug(f"Tracking job hash {_hash}")
 
+        self._logger.debug("Updating staging post-run")
+
+        if mode in [fdp_com.CMD_MODE.RUN, fdp_com.CMD_MODE.PULL]:
+            self._stager.update_data_product_staging()
+
         # Automatically add the run to tracking but unstaged
-        self._stager.change_job_stage_status(_hash, False)
+        self._stager.add_to_staging(_hash, "job")
 
         return _hash
 
@@ -451,7 +456,7 @@ class FAIR:
         """
         self.check_is_repo()
         if type_to_stage == "data_product":
-            self._stager.change_data_product_stage_status(identifier, stage)
+            self._stager.change_stage_status(identifier, type_to_stage, stage)
         else:
             self._stager.change_job_stage_status(identifier, stage)
 
@@ -535,7 +540,7 @@ class FAIR:
         self._logger.debug("Getting DataProducts staging status")
         self.check_is_repo()
 
-        self._stager.update_data_product_staging()  # TODO: Move to pull and run methods, here for development
+        self._stager.update_data_product_staging()
         _staged_data_products = self._stager.get_item_list(True, "data_product")
         _unstaged_data_products = self._stager.get_item_list(False, "data_product")
 

--- a/fair/staging.py
+++ b/fair/staging.py
@@ -161,7 +161,8 @@ class Stager:
         if not fdp_run.get_job_dir(job_id):
             raise fdp_exc.StagingError(f"Failed to recognise job with ID '{job_id}'")
 
-        self.change_stage_status(job_id, "job", stage, add_entry=True)
+        self.add_to_staging(job_id, "job")
+        self.change_stage_status(job_id, "job", stage)
 
     def find_registry_entry_for_file(self, local_uri: str, file_path: str) -> str:
         """Performs a rough search for a file in the local registry

--- a/fair/staging.py
+++ b/fair/staging.py
@@ -143,7 +143,7 @@ class Stager:
     def change_data_product_stage_status(
         self, data_product_id: str, stage: bool = True
     ) -> None:
-        self.change_stage_status(data_product_id, "data_product", stage, add_entry=False)
+        self.change_stage_status(data_product_id, "data_product", stage)
 
     def change_job_stage_status(self, job_id: str, stage: bool = True) -> None:
         """Stage a local code job ready to be pushed to the remote registry

--- a/fair/user_config/__init__.py
+++ b/fair/user_config/__init__.py
@@ -33,7 +33,6 @@ JOB2CLI_MAPPINGS = {
     "run_metadata.write_data_store": "registries.local.data_store",
 }
 
-
 class JobConfiguration(MutableMapping):
     _logger = logging.getLogger("FAIRDataPipeline.ConfigYAML")
     _block_types = ("register", "write", "read")
@@ -621,12 +620,17 @@ class JobConfiguration(MutableMapping):
 
             _name = item["use"]["data_product"]
             _namespace = item["use"]["namespace"]
+            _id_namespace = fdp_reg.convert_key_value_to_id(
+                self.local_uri,
+                "namespace",
+                _namespace
+            )
 
             if "${{" in _version:
                 _results = fdp_req.get(
                     self.local_uri,
                     "data_product",
-                    params={"name": _name, "namespace": _namespace},
+                    params={"name": _name, "namespace": _id_namespace},
                 )
             else:
                 _results = fdp_req.get(
@@ -634,7 +638,7 @@ class JobConfiguration(MutableMapping):
                     "data_product",
                     params={
                         "name": _name,
-                        "namespace": _namespace,
+                        "namespace": _id_namespace,
                         "version": _version,
                     },
                 )

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -35,7 +35,9 @@ def test_job_status_change(
 
     mocker.patch("fair.run.get_job_dir", lambda x: True)
 
-    stager.change_job_stage_status(str(_id), True)
+    stager.add_to_staging(str(_id), "job")
+
+    stager.change_job_stage_status(_id, True)
 
     with open(stager._staging_file) as stage_f:
         _dict = yaml.safe_load(stage_f)

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -37,7 +37,7 @@ def test_job_status_change(
 
     stager.add_to_staging(str(_id), "job")
 
-    stager.change_job_stage_status(_id, True)
+    stager.change_job_stage_status(str(_id), True)
 
     with open(stager._staging_file) as stage_f:
         _dict = yaml.safe_load(stage_f)

--- a/tests/test_with_api.py
+++ b/tests/test_with_api.py
@@ -9,9 +9,10 @@ import pytest
 import pytest_mock
 
 from fair.cli import cli
-from fair.common import FAIR_CLI_CONFIG, FAIR_FOLDER
+from fair.common import FAIR_FOLDER, default_data_dir
 from fair.registry.requests import get
 from tests.conftest import RegistryTest
+import fair.registry.server as fdp_serv
 
 PYTHON_API_GIT = "https://github.com/FAIRDataPipeline/pyDataPipeline.git"
 REPO_ROOT = pathlib.Path(os.path.dirname(__file__)).parent
@@ -35,9 +36,13 @@ def test_pull(local_config: typing.Tuple[str, str],
     with _cli_runner.isolated_filesystem(_proj_dir):
         with remote_registry, local_registry:
             os.makedirs(os.path.join(_proj_dir, FAIR_FOLDER), exist_ok=True)
+            _data = os.path.join(local_registry._install, "data")
+            os.makedirs(_data)
+            fdp_serv.update_registry_post_setup(_proj_dir, True)
             with open(os.path.join(_proj_dir, FAIR_FOLDER, "staging"), "w") as sf:
                 yaml.dump({"data_product": {}, "file": {}, "job": {}}, sf)
             mocker.patch("fair.common.staging_cache", lambda *args: os.path.join(_proj_dir, FAIR_FOLDER, "staging"))
+            mocker.patch("fair.configuration.get_local_data_store", lambda *args: _data)
             _cfg_path = os.path.join(
                 _proj_dir,
                 "src",
@@ -47,6 +52,12 @@ def test_pull(local_config: typing.Tuple[str, str],
                 "ext",
                 "SEIRSconfig.yaml"
             )
+            with open(_cfg_path) as cfg_file:
+                _cfg = yaml.safe_load(cfg_file)
+            
+            _cfg["run_metadata"]["write_data_store"] = _data
+            with open(_cfg_path, "w") as cfg_file:
+                yaml.dump(_cfg, cfg_file)
             with capsys.disabled():
                 print(f"\tRUNNING: fair pull {_cfg_path} --debug")
             _res = _cli_runner.invoke(cli, ["pull", _cfg_path, "--debug"])
@@ -67,9 +78,144 @@ def test_pull(local_config: typing.Tuple[str, str],
                 }
             )
 
+            assert get(
+                "http://127.0.0.1:8000/api/",
+                "user_author"
+            )
+
+
+@pytest.mark.with_api
+@pytest.mark.dependency(name='run', depends=['pull'])
+def test_run(local_config: typing.Tuple[str, str],
+    local_registry: RegistryTest,
+    remote_registry: RegistryTest,
+    mocker: pytest_mock.MockerFixture,
+    capsys):
+    try:
+        import org.fairdatapipeline
+    except ModuleNotFoundError:
+        pytest.skip("Python API implementation not installed")
+    mocker.patch("fair.configuration.get_remote_token", lambda *args: remote_registry._token)
+    mocker.patch("fair.registry.requests.local_token", lambda *args: local_registry._token)
+    mocker.patch("fair.registry.server.launch_server", lambda *args, **kwargs: True)
+    mocker.patch("fair.registry.server.stop_server", lambda *args: True)
+    _cli_runner = click.testing.CliRunner()
+    _proj_dir = os.path.join(local_config[1], "code")
+    _repo = git.Repo.clone_from(PYTHON_API_GIT, to_path=_proj_dir)
+    _repo.git.checkout("dev")
+    with _cli_runner.isolated_filesystem(_proj_dir):
+        with remote_registry, local_registry:
+            os.makedirs(os.path.join(_proj_dir, FAIR_FOLDER), exist_ok=True)
+            _data = os.path.join(local_registry._install, "data")
+            mocker.patch("fair.configuration.get_local_data_store", lambda *args: _data)
+            os.makedirs(_data, exist_ok=True)
+
+            assert os.path.exists(
+                os.path.join(
+                    _data,
+                    "testing",
+                    "SEIRS_model",
+                    "parameters",
+                    "1.0.0.csv"
+                )
+            )
+            with open(os.path.join(_proj_dir, FAIR_FOLDER, "staging"), "w") as sf:
+                yaml.dump({"data_product": {"testing:SEIRS_model/parameters@v1.0.0": False}, "file": {}, "job": {}}, sf)
+            mocker.patch("fair.common.staging_cache", lambda *args: os.path.join(_proj_dir, FAIR_FOLDER, "staging"))
+            
+            assert get(
+                "http://127.0.0.1:8000/api/",
+                "user_author"
+            )
+            
+
+            _cfg_path = os.path.join(
+                _proj_dir,
+                "src",
+                "org",
+                "fairdatapipeline",
+                "simpleModel",
+                "ext",
+                "SEIRSconfig.yaml"
+            )
+
+            with open(_cfg_path) as cfg_file:
+                _cfg = yaml.safe_load(cfg_file)
+            
+            _cfg["run_metadata"]["script"] = _cfg["run_metadata"]["script"].replace("src", f"{_proj_dir}/src")
+            _cfg["run_metadata"]["write_data_store"] = _data
+
+            with open(_cfg_path, "w") as cfg_file:
+                yaml.dump(_cfg, cfg_file)
+
+            with capsys.disabled():
+                print(f"\tRUNNING: fair run {_cfg_path} --debug")
+
+            _res = _cli_runner.invoke(cli, ["run", _cfg_path, "--debug", "--dirty"])
+
+            assert _res.exit_code == 0
+
+            assert get(
+                "http://127.0.0.1:8000/api/",
+                "data_product",
+                params={
+                    "name": "SEIRS_model/results/figure/python",
+                    "version": "0.0.1"
+                }
+            )
+
+
 @pytest.mark.with_api
 @pytest.mark.dependency(name='push', depends=['pull'])
-def test_push(local_config: typing.Tuple[str, str],
+def test_push_initial(local_config: typing.Tuple[str, str],
+    local_registry: RegistryTest,
+    remote_registry: RegistryTest,
+    mocker: pytest_mock.MockerFixture,
+    capsys):
+    mocker.patch("fair.configuration.get_remote_token", lambda *args: remote_registry._token)
+    mocker.patch("fair.registry.requests.local_token", lambda *args: local_registry._token)
+    mocker.patch("fair.registry.server.launch_server", lambda *args, **kwargs: True)
+    mocker.patch("fair.registry.server.stop_server", lambda *args: True)
+    _cli_runner = click.testing.CliRunner()
+    _proj_dir = os.path.join(local_config[1], "code")
+    _repo = git.Repo.clone_from(PYTHON_API_GIT, to_path=_proj_dir)
+    _repo.git.checkout("dev")
+    with _cli_runner.isolated_filesystem(_proj_dir):
+        with remote_registry, local_registry:
+            os.makedirs(os.path.join(_proj_dir, FAIR_FOLDER), exist_ok=True)
+            _data = os.path.join(local_registry._install, "data")
+            mocker.patch("fair.configuration.get_local_data_store", lambda *args: _data)
+            os.makedirs(_data, exist_ok=True)
+            with open(os.path.join(_proj_dir, FAIR_FOLDER, "staging"), "w") as sf:
+                yaml.dump({"data_product": {"testing:SEIRS_model/parameters@v1.0.0": False}, "file": {}, "job": {}}, sf)
+            mocker.patch("fair.common.staging_cache", lambda *args: os.path.join(_proj_dir, FAIR_FOLDER, "staging"))
+            fdp_serv.update_registry_post_setup(_proj_dir, True)
+
+            with capsys.disabled():
+                print("\tRUNNING: fair add testing:SEIRS_model/parameters@v1.0.0")
+
+            _res = _cli_runner.invoke(cli, ["add", "testing:SEIRS_model/parameters@v1.0.0"])
+
+            assert _res.exit_code == 0
+
+            with capsys.disabled():
+                print("\tRUNNING: fair push")
+
+            _res = _cli_runner.invoke(cli, ["push", "--debug"])
+
+            assert _res.exit_code == 0
+
+            assert get(
+                "http://127.0.0.1:8001/api/",
+                "data_product",
+                params={"name": "SEIRS_model/parameters", "version": "1.0.0"},
+                token=remote_registry._token
+            )
+
+
+@pytest.mark.with_api
+@pytest.mark.dependency(name='push', depends=['pull', 'run'])
+def test_push_postrun(local_config: typing.Tuple[str, str],
     local_registry: RegistryTest,
     remote_registry: RegistryTest,
     mocker: pytest_mock.MockerFixture,
@@ -86,25 +232,39 @@ def test_push(local_config: typing.Tuple[str, str],
         with remote_registry, local_registry:
             os.makedirs(os.path.join(_proj_dir, FAIR_FOLDER), exist_ok=True)
             with open(os.path.join(_proj_dir, FAIR_FOLDER, "staging"), "w") as sf:
-                yaml.dump({"data_product": {}, "file": {}, "job": {}}, sf)
+                yaml.dump({"data_product": {"testing:SEIRS_model/results/figure/python@v0.0.1": False}, "file": {}, "job": {}}, sf)
             mocker.patch("fair.common.staging_cache", lambda *args: os.path.join(_proj_dir, FAIR_FOLDER, "staging"))
-
+            fdp_serv.update_registry_post_setup(_proj_dir, True)
+            with open(os.path.join(_proj_dir, FAIR_FOLDER, "staging")) as cfg:
+                _staging = yaml.safe_load(cfg)
+            assert "testing:SEIRS_model/results/figure/python@v0.0.1" in _staging["data_product"]
+            mocker.patch("fair.configuration.get_local_data_store", lambda *args: os.path.join(local_registry._install, "data"))
             with capsys.disabled():
-                print("\tRUNNING: fair add testing:SEIRS_model/parameters@v1.0.0")
+                print("\tRUNNING: fair add testing:SEIRS_model/results/figure/python@v0.0.1")
 
-            _res = _cli_runner.invoke(cli, ["add", "testing:SEIRS_model/parameters@v1.0.0"])
+            assert get(
+                "http://127.0.0.1:8000/api/",
+                "data_product",
+                params={
+                    "name": "SEIRS_model/results/figure/python",
+                    "version": "0.0.1"
+                }
+            )
+
+            _res = _cli_runner.invoke(cli, ["add", "testing:SEIRS_model/results/figure/python@v0.0.1"])
 
             assert _res.exit_code == 0
-            
+
             with capsys.disabled():
                 print("\tRUNNING: fair push")
 
             _res = _cli_runner.invoke(cli, ["push", "--debug"])
 
             assert _res.exit_code == 0
+
             assert get(
                 "http://127.0.0.1:8001/api/",
                 "data_product",
-                {"name": "SEIRS_model/parameters", "version": "1.0.0"},
+                params={"name": "SEIRS_model/results/figure/python", "version": "0.0.1"},
                 token=remote_registry._token
             )


### PR DESCRIPTION
Bug where parameters for queries during push were sent to headers instead, this is fixed along with addition of tests of `fair pull`, `fair run` and `fair push`.