### PR TITLE
Specify FAIR registry via environment variable

### DIFF
--- a/fair/common.py
+++ b/fair/common.py
@@ -69,7 +69,10 @@ class CMD_MODE(enum.Enum):
 
 def registry_home() -> str:
     if not os.path.exists(global_fdpconfig()):
-        return DEFAULT_REGISTRY_LOCATION
+        if 'FAIR_REGISTRY_DIR' in os.environ:
+            return os.environ['FAIR_REGISTRY_DIR']
+        else:
+            return DEFAULT_REGISTRY_LOCATION
     _glob_conf = yaml.safe_load(open(global_fdpconfig()))
     if not _glob_conf:
         return DEFAULT_REGISTRY_LOCATION

--- a/fair/configuration/__init__.py
+++ b/fair/configuration/__init__.py
@@ -622,6 +622,8 @@ def global_config_query(registry: str = None) -> typing.Dict[str, typing.Any]:
     """Ask user question set for creating global FAIR config"""
     logger.debug("Running global configuration query with registry at '%s'", registry)
     click.echo("Checking for local registry")
+    if not registry and 'FAIR_REGISTRY_DIR' in os.environ:
+        registry = os.environ['FAIR_REGISTRY_DIR']
     check_reg = check_registry_exists(registry)
     if check_reg:
         registry = check_reg

--- a/fair/testing.py
+++ b/fair/testing.py
@@ -38,7 +38,10 @@ def create_configurations(
         A CLI configuration dictionary that can be loaded for a the CLI session
     """
     if not registry_dir:
-        registry_dir = fdp_com.DEFAULT_REGISTRY_LOCATION
+        if 'FAIR_REGISTRY_DIR' in os.environ:
+            registry_dir = os.environ['FAIR_REGISTRY_DIR']
+        else:
+            registry_dir = fdp_com.DEFAULT_REGISTRY_LOCATION
     if not remote_reg_dir:
         remote_reg_dir = os.path.join(
             os.path.dirname(fdp_com.DEFAULT_REGISTRY_LOCATION), "registry-rem"


### PR DESCRIPTION
Specify in advance an alternative location for the FAIR local registry using the environment variable `FAIR_REGISTRY_DIR`.