### PR TITLE
Ask before allowing `init` in a sub-location of existing FAIR repo

### DIFF
--- a/fair/session.py
+++ b/fair/session.py
@@ -819,6 +819,18 @@ class FAIR:
             click.echo("FAIR repository is already initialised.")
             return
 
+        _existing = fdp_com.find_fair_root(self._session_loc)
+
+        if _existing:
+            click.echo(
+                "A FAIR repository was initialised for this location at"
+                f" '{_existing}'"
+            )
+            _confirm = click.confirm("Do you want to continue?", default=False)
+            if not _confirm:
+                click.echo("Aborted intialisation.")
+                return
+
         if not using:
             click.echo(
                 "Initialising FAIR repository, setup will now ask for basic info:\n"


### PR DESCRIPTION
If the user runs `fair init` within the subdirectory of an existing FAIR repo, they will be asked to confirm this is what they want to do.

Closes #3 