### PR TITLE
If python3.exe is not found windows should fall back to python.exe

### DIFF
--- a/fair/virtualenv.py
+++ b/fair/virtualenv.py
@@ -34,7 +34,10 @@ class FAIREnv(EnvBuilder):
         _context: SimpleNamespace = super().ensure_directories(env_dir)
         _python_exe = shutil.which("python3")
         if not _python_exe:
-            raise PythonExecutableIdentificationError
+            self._logger.warning("python3.exe not found trying python.exe")
+            _python_exe = shutil.which("python")
+            if not _python_exe:
+                raise PythonExecutableIdentificationError
 
         self._logger.debug(f"Using python '{_python_exe}' for setup")
 


### PR DESCRIPTION
When activating a venv, python3 is already installed but may be known to windows as python.exe and not aliased as python3.exe, therefore the CLI should fall back to python.exe.